### PR TITLE
Fix wind plot geometry

### DIFF
--- a/src/erad/models/hazard/wind.py
+++ b/src/erad/models/hazard/wind.py
@@ -104,8 +104,8 @@ class WindModel(BaseDisasterModel):
     ) -> int:
         figure.add_trace(
             map_obj(
-                lat=[self.center.x],
-                lon=[self.center.y],
+                lat=[self.center.y],
+                lon=[self.center.x],
                 mode="markers",
                 marker=dict(
                     size=[self.radius_of_closest_isobar.magnitude / 5],
@@ -119,8 +119,8 @@ class WindModel(BaseDisasterModel):
 
         figure.add_trace(
             map_obj(
-                lat=[self.center.x],
-                lon=[self.center.y],
+                lat=[self.center.y],
+                lon=[self.center.x],
                 mode="markers",
                 marker=dict(
                     size=[self.radius_of_max_wind.magnitude / 5],


### PR DESCRIPTION
"In Shapely, a Point object is defined by its x and y coordinates. When working with geographic coordinates (latitude and longitude), the convention is that longitude corresponds to the x-coordinate and latitude corresponds to the y-coordinate."

Switch plotting function so that center.x = longitude and center.y = latitude