### PR TITLE
feat(mcp): add export_to_gdm tool (write tracked changes back to GDM)

### DIFF
--- a/src/erad/mcp/export.py
+++ b/src/erad/mcp/export.py
@@ -4,8 +4,11 @@ Export tools for ERAD MCP Server.
 
 import json
 
+from gdm.distribution import DistributionSystem
+from gdm.tracked_changes import apply_updates_to_system, filter_tracked_changes_by_name_and_date
 from loguru import logger
 
+from .simulation import _resolve_model_ref_to_path
 from .state import state
 
 
@@ -114,4 +117,60 @@ async def export_tracked_changes_tool(args: dict) -> dict:
 
     except Exception as e:
         logger.error(f"Error exporting tracked changes: {e}")
+        return {"error": str(e)}
+
+
+async def export_to_gdm_tool(args: dict) -> dict:
+    """Apply tracked changes to a source GDM DistributionSystem and export updated JSON."""
+    simulation_id = args["simulation_id"]
+    output_path = args["output_path"]
+    scenario_name = args.get("scenario_name")
+    source_model_ref = args.get("model_ref")
+    source_path = args.get("source_path")
+
+    try:
+        if simulation_id not in state.simulation_results:
+            return {"error": f"Simulation not found: {simulation_id}"}
+
+        sim_info = state.simulation_results[simulation_id]
+
+        if "tracked_changes" not in sim_info:
+            return {"error": "No tracked changes found. Run generate_scenarios first."}
+
+        tracked_changes = sim_info["tracked_changes"]
+        if scenario_name:
+            tracked_changes = filter_tracked_changes_by_name_and_date(
+                tracked_changes,
+                scenario_name=scenario_name,
+            )
+
+        if isinstance(source_model_ref, dict):
+            file_path = _resolve_model_ref_to_path(source_model_ref)
+        elif isinstance(source_path, str) and source_path.strip():
+            file_path = source_path
+        else:
+            return {
+                "error": (
+                    "Expected either model_ref (object) or source_path (string) "
+                    "for the original GDM DistributionSystem"
+                )
+            }
+
+        dist_system = DistributionSystem.from_json(file_path)
+        updated_system = apply_updates_to_system(tracked_changes, dist_system, None)
+        updated_system.to_json(output_path, overwrite=True)
+
+        logger.info(
+            f"Exported updated GDM model with {len(tracked_changes)} tracked changes to {output_path}"
+        )
+
+        return {
+            "success": True,
+            "output_path": output_path,
+            "tracked_change_count": len(tracked_changes),
+            "message": f"Updated GDM DistributionSystem exported to {output_path}",
+        }
+
+    except Exception as e:
+        logger.error(f"Error exporting updated GDM model: {e}")
         return {"error": str(e)}

--- a/src/erad/mcp/server.py
+++ b/src/erad/mcp/server.py
@@ -53,6 +53,7 @@ from .export import (
     export_to_sqlite_tool,
     export_to_json_tool,
     export_tracked_changes_tool,
+    export_to_gdm_tool,
 )
 from .cache import (
     list_cached_models_tool,
@@ -503,6 +504,38 @@ def _get_tools() -> list[Tool]:
                 "required": ["simulation_id", "output_path"],
             },
         ),
+        Tool(
+            name="export_to_gdm",
+            description=(
+                "Apply ERAD simulation tracked changes (e.g. asset outages) back onto the "
+                "original GDM DistributionSystem and write the updated model to JSON. "
+                "The original model must be provided via model_ref or source_path because "
+                "ERAD only caches the AssetSystem, not the raw DistributionSystem."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "simulation_id": {
+                        "type": "string",
+                        "description": "ID of simulation with tracked changes",
+                    },
+                    "output_path": {"type": "string", "description": "Output file path"},
+                    "model_ref": {
+                        "type": "object",
+                        "description": "Model reference ({model_id/version} or direct stored_path/path) for the original GDM distribution model",
+                    },
+                    "source_path": {
+                        "type": "string",
+                        "description": "Path to the original GDM distribution model JSON when model_ref is not provided",
+                    },
+                    "scenario_name": {
+                        "type": "string",
+                        "description": "Optional scenario name to filter tracked changes before applying",
+                    },
+                },
+                "required": ["simulation_id", "output_path"],
+            },
+        ),
         # Cache Management
         Tool(
             name="list_cached_models",
@@ -585,6 +618,7 @@ _TOOL_HANDLERS = {
     "export_to_sqlite": export_to_sqlite_tool,
     "export_to_json": export_to_json_tool,
     "export_tracked_changes": export_tracked_changes_tool,
+    "export_to_gdm": export_to_gdm_tool,
     "list_cached_models": list_cached_models_tool,
     "get_cache_info": get_cache_info_tool,
     "search_documentation": search_documentation_tool,


### PR DESCRIPTION
## Summary
Adds an `export_to_gdm` MCP tool that applies ERAD simulation tracked-changes (e.g. asset outages) back onto the original GDM `DistributionSystem` and writes the updated model to JSON. This closes the ERAD→GDM loop so a resilience scenario can chain directly into a follow-on power flow.

## Implementation
- `src/erad/mcp/export.py`: `export_to_gdm_tool` — reloads the source GDM via `model_ref`/`source_path`, applies `gdm.tracked_changes.apply_updates_to_system`, optional `scenario_name` filter, writes `to_json`.
- `src/erad/mcp/server.py`: registered the tool (schema + `_TOOL_HANDLERS`).
- Business logic reuses existing GDM API; no changes to solver/loaders.

## Verification
- Full erad suite: **114 passed**.
- Tool registered and callable; import + `_get_tools()` confirmed.

🤖 Generated with opencode